### PR TITLE
Fix unmarshalling of `policy-id` in `mapping.yaml`

### DIFF
--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -60,7 +60,7 @@ type PolicyMappingFile struct {
 }
 
 type PolicyMirror struct {
-	PolicyId string     `json:"policy-id"`
+	PolicyId string     `yaml:"policy-id"`
 	Mirror   MirrorSpec `json:"mirror"`
 }
 
@@ -120,7 +120,7 @@ func resolveLocalPolicy(opts *PolicyOptions, mapping *PolicyMapping) (*Policy, e
 	return policy, nil
 }
 
-func loadLocalMappings(opts *PolicyOptions) (*PolicyMappings, error) {
+func LoadLocalMappings(opts *PolicyOptions) (*PolicyMappings, error) {
 	if opts.LocalPolicyDir == "" {
 		return nil, nil
 	}
@@ -204,7 +204,7 @@ func ResolvePolicy(ctx context.Context, resolver oci.AttestationResolver, opts *
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image name: %w", err)
 	}
-	localMappings, err := loadLocalMappings(opts)
+	localMappings, err := LoadLocalMappings(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load local policy mappings: %w", err)
 	}

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -84,3 +84,15 @@ func TestRegoEvaluator_Evaluate(t *testing.T) {
 	}
 
 }
+
+func TestLoadingMappings(t *testing.T) {
+	opts := &policy.PolicyOptions{
+		LocalPolicyDir: filepath.Join("testdata", "mock-tuf-allow"),
+	}
+	policyMappings, err := policy.LoadLocalMappings(opts)
+	require.NoError(t, err)
+	assert.Equal(t, len(policyMappings.Mirrors), 1)
+	for _, mirror := range policyMappings.Mirrors {
+		assert.Equal(t, "docker-official-images", mirror.PolicyId)
+	}
+}

--- a/pkg/policy/testdata/mock-tuf-allow/mapping.yaml
+++ b/pkg/policy/testdata/mock-tuf-allow/mapping.yaml
@@ -9,3 +9,8 @@ policies:
     description: Docker Official Images
     files:
       - path: doi/policy.rego
+mirrors:
+  - policy-id: docker-official-images
+    mirror:
+      domains: [localhost:5001, registry.local:5000]
+      prefix: ""


### PR DESCRIPTION
`policy-id` was being unmarshalled as ""