### PR TITLE
Avoid pointers to map

### DIFF
--- a/pkg/attest/verify.go
+++ b/pkg/attest/verify.go
@@ -37,7 +37,7 @@ func ToPolicyResult(p *policy.Policy, input *policy.PolicyInput, result *policy.
 	}
 	subject := intoto.Subject{
 		Name:   input.Purl,
-		Digest: *dgst,
+		Digest: dgst,
 	}
 	resourceUri, err := attestation.ToVSAResourceURI(subject)
 	if err != nil {

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -549,12 +549,12 @@ func RefToPURL(ref string, platform *v1.Platform) (string, bool, error) {
 	return p.ToString(), isCanonical, nil
 }
 
-func SplitDigest(digest string) (*common.DigestSet, error) {
+func SplitDigest(digest string) (common.DigestSet, error) {
 	parts := strings.SplitN(digest, ":", 2)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid digest %q", digest)
 	}
-	return &common.DigestSet{
+	return common.DigestSet{
 		parts[0]: parts[1],
 	}, nil
 }


### PR DESCRIPTION
`common.DigestSet` is a map and maps are already reference types.