### PR TITLE
Don't upload coverage results if we don't run e2e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,13 +40,14 @@ jobs:
         uses: atomicjar/testcontainers-cloud-setup-action@v1
         with:
           token: ${{ secrets.TC_CLOUD_TOKEN }}
-      - name: go test ubuntu e2e
+      - name: go test including e2e
         if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
         run: go test -tags=e2e -v ./... -coverprofile=coverage.out -covermode=atomic
-      - name: go test osx
+      - name: go test excluding e2e
         if: matrix.os == 'macos-latest' || github.actor == 'dependabot[bot]'
-        run: go test -v ./... -coverprofile=coverage.out -covermode=atomic
+        run: go test -v ./...
       - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.out


### PR DESCRIPTION
this way the coverage doesn't fluctuate between e2e and non-e2e test runs