### PR TITLE
continue-on-error if TCC client can't be setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
         uses: atomicjar/testcontainers-cloud-setup-action@v1
         with:
           token: ${{ secrets.TC_CLOUD_TOKEN }}
+        continue-on-error: true
       - name: go test including e2e
         if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
         run: go test -tags=e2e -v ./... -coverprofile=coverage.out -covermode=atomic


### PR DESCRIPTION
This is to mitigate [an ongoing incident](https://docker.slack.com/archives/C01TMK50REK/p1721048120847489) but probably not a bad setting to have enabled anyway.