### PR TITLE
chore: disable codecov patch status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,5 @@
 ignore:
   - "internal/test"
+coverage:
+  status:
+    patch: false


### PR DESCRIPTION
I don't find the `codecov/patch` CI check very helpful and the code annotations crowd the PR code diff. You can hide the annotations in the diff manually but I am pretty sure we can just disable this and use the `codecov/project` check for PRs.