### PR TITLE
feat: add slsa v1 predicate type

### DIFF
--- a/attestation/types.go
+++ b/attestation/types.go
@@ -7,6 +7,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	v02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	slsav1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -98,6 +99,8 @@ type Options struct {
 func DSSEMediaType(predicateType string) (string, error) {
 	var predicateName string
 	switch predicateType {
+	case slsav1.PredicateSLSAProvenance:
+		predicateName = "provenance"
 	case v02.PredicateSLSAProvenance:
 		predicateName = "provenance"
 	case intoto.PredicateSPDX:

--- a/attestation/types_test.go
+++ b/attestation/types_test.go
@@ -1,0 +1,44 @@
+package attestation
+
+import (
+	"fmt"
+	"testing"
+
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
+	v02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	slsav1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDSSEMediaType(t *testing.T) {
+	testcases := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     slsav1.PredicateSLSAProvenance,
+			expected: "provenance",
+		},
+		{
+			name:     v02.PredicateSLSAProvenance,
+			expected: "provenance",
+		},
+		{
+			name:     intoto.PredicateSPDX,
+			expected: "spdx",
+		},
+		{
+			name:     VSAPredicateType,
+			expected: "verification_summary",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mt, err := DSSEMediaType(tc.name)
+			require.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("application/vnd.in-toto.%s+dsse", tc.expected), mt)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- small change to support SLSA v1 predicate type

### Fixes
`Error: failed to add attestation: failed to create signed layer: failed to get DSSE media type: unknown predicate type "https://slsa.dev/provenance/v1"`
