### PR TITLE
fix: suppress logs from ecr credential helper

### DIFF
--- a/oci/authn.go
+++ b/oci/authn.go
@@ -1,6 +1,8 @@
 package oci
 
 import (
+	"io"
+
 	ecr "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/google"
@@ -16,6 +18,6 @@ func MultiKeychainAll() authn.Keychain {
 	return authn.NewMultiKeychain(
 		authn.DefaultKeychain,
 		google.Keychain,
-		authn.NewKeychainFromHelper(ecr.NewECRHelper()),
+		authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(io.Discard))),
 	)
 }


### PR DESCRIPTION
This gets rid of those annoying logs like:

```
time="2024-09-11T15:22:04Z" level=error msg="Error parsing the serverURL" error="docker-credential-ecr-login can only be used with Amazon Elastic Container Registry." serverURL="localhost:5000"
time="2024-09-11T15:22:04Z" level=error msg="Error parsing the serverURL" error="docker-credential-ecr-login can only be used with Amazon Elastic Container Registry." serverURL="localhost:5000"
time="2024-09-11T15:22:04Z" level=error msg="Error parsing the serverURL" error="docker-credential-ecr-login can only be used with Amazon Elastic Container Registry." serverURL="localhost:5000"
time="2024-09-11T15:22:04Z" level=error msg="Error parsing the serverURL" error="docker-credential-ecr-login can only be used with Amazon Elastic Container Registry." serverURL="localhost:5000"
```