### PR TITLE
fix: only sign statements

### DIFF
--- a/attestation/attestation.go
+++ b/attestation/attestation.go
@@ -96,8 +96,9 @@ func layersFromImage(image v1.Image) ([]*Layer, error) {
 		// copy original annotations
 		ann := maps.Clone(layerDesc.Annotations)
 		// only decode intoto statements
-		stmt := new(intoto.Statement)
+		var stmt *intoto.Statement
 		if mt == types.MediaType(intoto.PayloadType) {
+			stmt = new(intoto.Statement)
 			err = json.NewDecoder(r).Decode(&stmt)
 			if err != nil {
 				return nil, fmt.Errorf("failed to decode statement layer contents: %w", err)

--- a/sign.go
+++ b/sign.go
@@ -19,9 +19,12 @@ func SignStatements(ctx context.Context, idx v1.ImageIndex, signer dsse.SignerVe
 	// sign every attestation layer in each manifest
 	for _, manifest := range attestationManifests {
 		for _, layer := range manifest.OriginalLayers {
-			err = manifest.Add(ctx, signer, layer.Statement, opts)
-			if err != nil {
-				return nil, fmt.Errorf("failed to sign attestation layer %w", err)
+			// skip layers without statements
+			if layer.Statement != nil {
+				err = manifest.Add(ctx, signer, layer.Statement, opts)
+				if err != nil {
+					return nil, fmt.Errorf("failed to sign attestation layer %w", err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## summary
- `SignStatements` attempts to sign attestation manifests that were already signed
```
Signing attestations on image at docker://notary:server
Error: failed to sign attestation: failed to sign attestation layer failed to create signed layer: failed to get DSSE media type: unknown predicate type ""
```
- only sign layers that have unsigned statements