### PR TITLE
feat: add pr and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,19 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: bug
+assignees: ""
+---
+
+**What steps did you take and what happened:**
+[A clear and concise description of what the bug is.]
+
+**What did you expect to happen:**
+
+**Anything else you would like to add:**
+[Miscellaneous information that will assist in solving the issue.]
+
+**Environment:**
+
+- Attest version:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**Describe the solution you'd like**
+[A clear and concise description of what you want to happen.]
+
+**Anything else you would like to add:**
+[Miscellaneous information that will assist in solving the issue.]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- Description of why the pull request is needed and what it changes -->
+
+### Tests
+
+<!-- Provide evidence of testing -->
+
+### Issue
+
+<!-- Link to issue that this is part of -->


### PR DESCRIPTION
## summary
- adds PR and Issue templates

Copied from `attest-provider` with some modifications, they are pretty minimal which is fine for now IMO. 