### PR TITLE
chore: skip DCO requirement for org members

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false


### PR DESCRIPTION
Members of the org shouldn't have to agree to the DCO, it's implicit.